### PR TITLE
Add Chrome extension to copy mobile.de listings

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,17 @@
+{
+  "manifest_version": 3,
+  "name": "Mobile.de Copier",
+  "version": "1.0",
+  "description": "Adds a button to mobile.de listings to copy data into the car table.",
+  "permissions": ["storage"],
+  "content_scripts": [
+    {
+      "matches": ["https://*.mobile.de/*", "http://*.mobile.de/*"],
+      "js": ["mobile.js"]
+    },
+    {
+      "matches": ["*://*/index.html"],
+      "js": ["table.js"]
+    }
+  ]
+}

--- a/extension/mobile.js
+++ b/extension/mobile.js
@@ -1,0 +1,47 @@
+(function() {
+  function extractData() {
+    const data = {};
+    data.brand = document.querySelector('h1')?.textContent?.trim() || '';
+    data.price = document.querySelector('[data-testid="prime-price"]')?.textContent?.trim() || '';
+    data.mileage = Array.from(document.querySelectorAll('.u-block')).find(el => el.textContent.includes('km'))?.textContent?.trim() || '';
+    const features = [];
+    document.querySelectorAll('[data-testid="basic-details-item"]').forEach(el => {
+      const t = el.textContent.trim();
+      if (t && !t.includes('km') && !t.includes('€')) features.push(t);
+    });
+    data.features = features.slice(0, 3).join(', ');
+    data.url = window.location.href;
+    return data;
+  }
+
+  function addButton() {
+    if (document.getElementById('copy-to-table-btn')) return;
+    const btn = document.createElement('button');
+    btn.id = 'copy-to-table-btn';
+    btn.textContent = '📋 Копіювати до таблиці';
+    Object.assign(btn.style, {
+      position: 'fixed',
+      top: '10px',
+      right: '10px',
+      zIndex: 9999,
+      padding: '8px 12px',
+      background: '#3498db',
+      color: 'white',
+      border: 'none',
+      borderRadius: '4px',
+      cursor: 'pointer'
+    });
+    btn.addEventListener('click', async () => {
+      const data = extractData();
+      const res = await chrome.storage.local.get('cars');
+      const list = res.cars || [];
+      list.push(data);
+      await chrome.storage.local.set({ cars: list });
+      btn.textContent = '✅ Скопійовано!';
+      setTimeout(() => { btn.textContent = '📋 Копіювати до таблиці'; }, 2000);
+    });
+    document.body.appendChild(btn);
+  }
+
+  addButton();
+})();

--- a/extension/table.js
+++ b/extension/table.js
@@ -1,0 +1,8 @@
+(async function() {
+  const res = await chrome.storage.local.get('cars');
+  const cars = res.cars;
+  if (cars && cars.length && typeof window.addCarFromExtension === 'function') {
+    cars.forEach(car => window.addCarFromExtension(car));
+    await chrome.storage.local.remove('cars');
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -1286,6 +1286,17 @@
             toggleAddForm();
         }
 
+        // Додати авто з розширення Chrome
+        async function addCarFromExtension(car) {
+            if (!car.id) {
+                car.id = 'ext_' + Date.now();
+            }
+            carsData.push(car);
+            await autoSave();
+            generateTable();
+            updateStats();
+        }
+
         // Видалити автомобіль
         async function deleteCar(carId) {
             if (confirm('Ви впевнені, що хочете видалити цей автомобіль?')) {


### PR DESCRIPTION
## Summary
- add a basic Chrome extension for copying mobile.de listing data
- inject a button on mobile.de pages to store listing data in `chrome.storage`
- on the table page, read stored data and add rows automatically
- expose `addCarFromExtension` in `index.html` to support the extension

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684717b3e2f88329838b628a15eb3518