### PR TITLE
Fix extension injection on file:// sites

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -10,7 +10,7 @@
       "js": ["mobile.js"]
     },
     {
-      "matches": ["*://*/index.html"],
+      "matches": ["*://*/index.html", "file://*/*"],
       "js": ["table.js"]
     }
   ]


### PR DESCRIPTION
## Summary
- update extension manifest to match `file://` URLs so data copied from mobile.de pages appears in the table when the site is opened from a local file

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847f2c82864832980e60494c96ff970